### PR TITLE
Added Dynamic Folders + Compatibility with Temlater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ main.js
 
 # obsidian
 data.json
+
+.history

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,6 +1,6 @@
+import builtins from 'builtin-modules'
 import esbuild from "esbuild";
 import process from "process";
-import builtins from 'builtin-modules'
 
 const banner =
 `/*
@@ -44,7 +44,7 @@ esbuild.build({
 		...builtins],
 	format: 'cjs',
 	watch: !prod,
-	target: 'es2016',
+	target: 'es2018',
 	logLevel: "info",
 	sourcemap: prod ? false : 'inline',
 	treeShaking: true,

--- a/main.ts
+++ b/main.ts
@@ -63,7 +63,7 @@ export default class AutoNoteMover extends Plugin {
 						if (matches) {
 							const match = regex.exec(matches);
 							if (match) {
-								const newSettingFolder = settingFolder.replace(/\$(\d)/g, (_, i) => match[i]);
+								const newSettingFolder = settingFolder.replace(/\$(\d)/g, (_, i) => match[i] || '');
 								fileMove(this, newSettingFolder, fileFullName, file, template);
 								break;
 							}

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,6 @@
-import { MarkdownView, Plugin, TFile, getAllTags, Notice, TAbstractFile, normalizePath } from 'obsidian';
-import { DEFAULT_SETTINGS, AutoNoteMoverSettings, AutoNoteMoverSettingTab } from 'settings/settings';
-import { fileMove, getTriggerIndicator, isFmDisable } from 'utils/Utils';
+import { App, MarkdownView, Notice, Plugin, TAbstractFile, TFile, getAllTags, normalizePath } from 'obsidian';
+import { AutoNoteMoverSettingTab, AutoNoteMoverSettings, DEFAULT_SETTINGS } from 'settings/settings';
+import { fileMove, findTFile, getTriggerIndicator, isFmDisable } from 'utils/Utils';
 
 export default class AutoNoteMover extends Plugin {
 	settings: AutoNoteMoverSettings;
@@ -54,17 +54,18 @@ export default class AutoNoteMover extends Plugin {
 				const settingFolder = folderTagPattern[i].folder;
 				const settingTag = folderTagPattern[i].tag;
 				const settingPattern = folderTagPattern[i].pattern;
+				const template = findTFile(folderTagPattern[i].template_file, this.app);
 				// Tag check
 				if (!settingPattern) {
 					if (!this.settings.use_regex_to_check_for_tags) {
 						if (cacheTag.find((e) => e === settingTag)) {
-							fileMove(this.app, settingFolder, fileFullName, file);
+							fileMove(this.app, settingFolder, fileFullName, file, template);
 							break;
 						}
 					} else if (this.settings.use_regex_to_check_for_tags) {
 						const regex = new RegExp(settingTag);
 						if (cacheTag.find((e) => regex.test(e))) {
-							fileMove(this.app, settingFolder, fileFullName, file);
+							fileMove(this.app, settingFolder, fileFullName, file, template);
 							break;
 						}
 					}
@@ -73,7 +74,7 @@ export default class AutoNoteMover extends Plugin {
 					const regex = new RegExp(settingPattern);
 					const isMatch = regex.test(fileName);
 					if (isMatch) {
-						fileMove(this.app, settingFolder, fileFullName, file);
+						fileMove(this.app, settingFolder, fileFullName, file, template);
 						break;
 					}
 				}

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
 	"author": "",
 	"license": "MIT",
 	"devDependencies": {
-		"@types/node": "^16.11.6",
-		"@typescript-eslint/eslint-plugin": "^5.2.0",
-		"@typescript-eslint/parser": "^5.2.0",
-		"builtin-modules": "^3.2.0",
-		"esbuild": "0.13.12",
-		"obsidian": "^0.12.17",
-		"tslib": "2.3.1",
-		"typescript": "4.4.4"
+		"@types/node": "^16.18.11",
+		"@typescript-eslint/eslint-plugin": "^5.49.0",
+		"@typescript-eslint/parser": "^5.49.0",
+		"builtin-modules": "^3.3.0",
+		"esbuild": "^0.14.54",
+		"obsidian": "^1.1.1",
+		"tslib": "^2.4.1",
+		"typescript": "^4.9.4"
 	},
 	"dependencies": {
 		"@popperjs/core": "^2.11.2"

--- a/settings/settings.ts
+++ b/settings/settings.ts
@@ -23,6 +23,7 @@ export interface AutoNoteMoverSettings {
 	folder_tag_pattern: Array<FolderTagPattern>;
 	use_regex_to_check_for_excluded_folder: boolean;
 	excluded_folder: Array<ExcludedFolder>;
+	create_non_existant_folders: boolean;
 }
 
 export const DEFAULT_SETTINGS: AutoNoteMoverSettings = {
@@ -32,6 +33,7 @@ export const DEFAULT_SETTINGS: AutoNoteMoverSettings = {
 	folder_tag_pattern: [{ folder: '', tag: '', pattern: '', template_file: '' }],
 	use_regex_to_check_for_excluded_folder: false,
 	excluded_folder: [{ folder: '' }],
+	create_non_existant_folders: false,
 };
 
 export class AutoNoteMoverSettingTab extends PluginSettingTab {
@@ -87,6 +89,17 @@ export class AutoNoteMoverSettingTab extends PluginSettingTab {
 						this.display();
 					})
 			);
+		new Setting(this.containerEl)
+		.setName('Create Folders if they don\'t exist')
+		.setDesc('This can be especially useful when using capture groups in the destination folder.')
+		.addToggle((toggle) => {
+			toggle.setValue(this.plugin.settings.create_non_existant_folders).onChange(async (value) => {
+				this.plugin.settings.create_non_existant_folders = value;
+				await this.plugin.saveSettings();
+				this.display();
+			});
+		});
+
 
 		const useRegexToCheckForTags = document.createDocumentFragment();
 		useRegexToCheckForTags.append(

--- a/settings/settings.ts
+++ b/settings/settings.ts
@@ -1,14 +1,15 @@
-import AutoNoteMover from 'main';
-import { App, Notice, PluginSettingTab, Setting, ButtonComponent } from 'obsidian';
+import { App, ButtonComponent, Notice, PluginSettingTab, Setting } from 'obsidian';
+import { FileSuggest, FolderSuggest } from 'suggests/file-suggest';
+import { arrayMove, getTemplater } from 'utils/Utils';
 
-import { FolderSuggest } from 'suggests/file-suggest';
+import AutoNoteMover from 'main';
 import { TagSuggest } from 'suggests/tag-suggest';
-import { arrayMove } from 'utils/Utils';
 
 export interface FolderTagPattern {
 	folder: string;
 	tag: string;
 	pattern: string;
+	template_file: string,
 }
 
 export interface ExcludedFolder {
@@ -28,7 +29,7 @@ export const DEFAULT_SETTINGS: AutoNoteMoverSettings = {
 	trigger_auto_manual: 'Automatic',
 	use_regex_to_check_for_tags: false,
 	statusBar_trigger_indicator: true,
-	folder_tag_pattern: [{ folder: '', tag: '', pattern: '' }],
+	folder_tag_pattern: [{ folder: '', tag: '', pattern: '', template_file: '' }],
 	use_regex_to_check_for_excluded_folder: false,
 	excluded_folder: [{ folder: '' }],
 };
@@ -57,23 +58,6 @@ export class AutoNoteMoverSettingTab extends PluginSettingTab {
 		new Setting(this.containerEl).setDesc(
 			'Auto Note Mover will automatically move the active notes to their respective folders according to the rules.'
 		);
-
-		/* new Setting(this.containerEl)
-			.setName('Auto Note Mover')
-			.setDesc('Enable or disable the Auto Note Mover.')
-			.addToggle((toggle) => {
-				toggle
-					.setValue(this.plugin.settings.enable_auto_note_mover)
-					.onChange(async (use_new_auto_note_mover) => {
-						this.plugin.settings.enable_auto_note_mover = use_new_auto_note_mover;
-						await this.plugin.saveSettings();
-						this.display();
-					});
-			});
-
-		if (!this.plugin.settings.enable_auto_note_mover) {
-			return;
-		} */
 
 		const triggerDesc = document.createDocumentFragment();
 		triggerDesc.append(
@@ -167,6 +151,7 @@ export class AutoNoteMoverSettingTab extends PluginSettingTab {
 							folder: '',
 							tag: '',
 							pattern: '',
+							template_file: '',
 						});
 						await this.plugin.saveSettings();
 						this.display();
@@ -231,8 +216,18 @@ export class AutoNoteMoverSettingTab extends PluginSettingTab {
 							this.plugin.settings.folder_tag_pattern[index].pattern = newPattern;
 							await this.plugin.saveSettings();
 						});
-				})
-				.addExtraButton((cb) => {
+				});
+			if (getTemplater(this.app)) s.addSearch((cb) => {
+				new FileSuggest(this.app, cb.inputEl);
+				cb.setPlaceholder('Template File')
+					.setValue(folder_tag_pattern.template_file)
+					.onChange(async (newTemplateFile) => {
+						this.plugin.settings.folder_tag_pattern[index].template_file = newTemplateFile.trim();
+						await this.plugin.saveSettings();
+					});
+			});
+
+			s.addExtraButton((cb) => {
 					cb.setIcon('up-chevron-glyph')
 						.setTooltip('Move up')
 						.onClick(async () => {

--- a/suggests/file-suggest.ts
+++ b/suggests/file-suggest.ts
@@ -6,11 +6,11 @@
 // *    Availability: https://github.com/liamcain/obsidian-periodic-notes
 // *
 // ***************************************************************************************
-import { TAbstractFile, TFolder } from 'obsidian';
+
+import { TAbstractFile, TFile, TFolder } from 'obsidian';
 
 import { TextInputSuggest } from './suggest';
 
-/* 
 export class FileSuggest extends TextInputSuggest<TFile> {
 	getSuggestions(inputStr: string): TFile[] {
 		const abstractFiles = this.app.vault.getAllLoadedFiles();
@@ -40,7 +40,6 @@ export class FileSuggest extends TextInputSuggest<TFile> {
 		this.close();
 	}
 }
- */
 
 export class FolderSuggest extends TextInputSuggest<TFolder> {
 	getSuggestions(inputStr: string): TFolder[] {

--- a/utils/Utils.ts
+++ b/utils/Utils.ts
@@ -51,7 +51,7 @@ export const fileMove = async (plugin: AutoNoteMover, settingFolder: string, fil
 	if (!isTFExists(app, settingFolder, TFolder)) {
 		if (settings.create_non_existant_folders) {
 			console.log(`[Auto Note Mover] Creating folder: ${settingFolder}`);
-			app.vault.createFolder(normalizePath(settingFolder));
+			await app.vault.createFolder(normalizePath(settingFolder));
 		} else {
 			console.error(`[Auto Note Mover] The destination folder "${settingFolder}" does not exist.`);
 			new Notice(`[Auto Note Mover]\n"Error: The destination folder\n"${settingFolder}"\ndoes not exist.`);

--- a/utils/Utils.ts
+++ b/utils/Utils.ts
@@ -1,7 +1,8 @@
-import { App, CachedMetadata, normalizePath, Notice, parseFrontMatterEntry, TFile, TFolder } from 'obsidian';
+import { App, CachedMetadata, Notice, TFile, TFolder, normalizePath, parseFrontMatterEntry } from 'obsidian';
 
 // Disable AutoNoteMover when "AutoNoteMover: disable" is present in the frontmatter.
 export const isFmDisable = (fileCache: CachedMetadata) => {
+	if(!fileCache) return false;
 	const fm = parseFrontMatterEntry(fileCache.frontmatter, 'AutoNoteMover');
 	if (fm === 'disable') {
 		return true;
@@ -27,7 +28,22 @@ const isTFExists = (app: App, path: string, F: typeof TFile | typeof TFolder) =>
 	}
 };
 
-export const fileMove = async (app: App, settingFolder: string, fileFullName: string, file: TFile) => {
+
+export function findTFile(name: string, app: App): TFile {
+	return app.metadataCache.getFirstLinkpathDest(normalizePath(name), "");
+}
+
+export function getTemplater(app: App) {
+	return app.plugins.plugins["templater-obsidian"]?.templater;
+}
+
+export async function writeTemplate(app: App, template: TFile) {
+	const templater = getTemplater(app);
+	if (templater?.append_template_to_active_file)
+		await templater.append_template_to_active_file(template);
+}
+
+export const fileMove = async (app: App, settingFolder: string, fileFullName: string, file: TFile, template: TFile) => {
 	// Does the destination folder exist?
 	if (!isTFExists(app, settingFolder, TFolder)) {
 		console.error(`[Auto Note Mover] The destination folder "${settingFolder}" does not exist.`);
@@ -49,6 +65,7 @@ export const fileMove = async (app: App, settingFolder: string, fileFullName: st
 	if (newPath === file.path) {
 		return;
 	}
+	if (template) await writeTemplate(app, template);
 	// Move file
 	await app.fileManager.renameFile(file, newPath);
 	console.log(`[Auto Note Mover] Moved the note "${fileFullName}" to the "${settingFolder}".`);

--- a/utils/Utils.ts
+++ b/utils/Utils.ts
@@ -1,5 +1,7 @@
 import { App, CachedMetadata, Notice, TFile, TFolder, normalizePath, parseFrontMatterEntry } from 'obsidian';
 
+import AutoNoteMover from '../main';
+
 // Disable AutoNoteMover when "AutoNoteMover: disable" is present in the frontmatter.
 export const isFmDisable = (fileCache: CachedMetadata) => {
 	if(!fileCache) return false;
@@ -43,12 +45,18 @@ export async function writeTemplate(app: App, template: TFile) {
 		await templater.append_template_to_active_file(template);
 }
 
-export const fileMove = async (app: App, settingFolder: string, fileFullName: string, file: TFile, template: TFile) => {
-	// Does the destination folder exist?
+export const fileMove = async (plugin: AutoNoteMover, settingFolder: string, fileFullName: string, file: TFile, template: TFile) => {
+	const { app, settings } = plugin;
+	console.log(`Setting Folder: ${settingFolder}`);
 	if (!isTFExists(app, settingFolder, TFolder)) {
-		console.error(`[Auto Note Mover] The destination folder "${settingFolder}" does not exist.`);
-		new Notice(`[Auto Note Mover]\n"Error: The destination folder\n"${settingFolder}"\ndoes not exist.`);
-		return;
+		if (settings.create_non_existant_folders) {
+			console.log(`[Auto Note Mover] Creating folder: ${settingFolder}`);
+			app.vault.createFolder(normalizePath(settingFolder));
+		} else {
+			console.error(`[Auto Note Mover] The destination folder "${settingFolder}" does not exist.`);
+			new Notice(`[Auto Note Mover]\n"Error: The destination folder\n"${settingFolder}"\ndoes not exist.`);
+			return;
+		}
 	}
 	// Does the file with the same name exist in the destination folder?
 	const newPath = normalizePath(settingFolder + '/' + fileFullName);


### PR DESCRIPTION
If Templater is detected, you can associate a template file with a rule so that it is run automatically when the file is moved.

Due to some kind of caching problem, the template is executed before the file is renamed, otherwise templater complains that the file doesn't exist. I would think that `await`ing the rename call would mean the rename is complete, but apparantly not.


How to use:
- Install Templater from community plugins
- go to the settings tab
- there is now a fourth suggester, select a template file
- create any file and trigger a move
- you should see the template appended to the file